### PR TITLE
Rename URIjs dependency to urijs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ url.host = 'example.net:8080';
 url.port; // '8080'
 ```
 
-Why `URIjs` instead of `url`?
+Why `urijs` instead of `url`?
 -----------------------------
 
 I tried it first, but Node's own URL module doesn't propagate changes, so

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var URI = require('URIjs');
+var URI = require('urijs');
 
 function URL(urlStr, base) {
   if (!urlStr) {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "mocha": "^2.2.5"
   },
   "dependencies": {
-    "URIjs": "^1.15.1"
+    "urijs": "^1.15.1"
   }
 }


### PR DESCRIPTION
`URIjs` has been renamed to `urijs`